### PR TITLE
Allow configuring the attestation in `generateRegistrationChallenge`

### DIFF
--- a/packages/server/src/registration.js
+++ b/packages/server/src/registration.js
@@ -43,7 +43,7 @@ exports.parseRegisterRequest = (body) => {
     };
 };
 
-exports.generateRegistrationChallenge = ({ relyingParty, user, attestation } = {}) => {
+exports.generateRegistrationChallenge = ({ relyingParty, user, attestation = 'direct' } = {}) => {
     if (!relyingParty || !relyingParty.name || typeof relyingParty.name !== 'string') {
         throw new Error('The typeof relyingParty.name should be a string');
     }
@@ -63,7 +63,7 @@ exports.generateRegistrationChallenge = ({ relyingParty, user, attestation } = {
             displayName: user.displayName || user.name,
             name: user.name
         },
-        attestation: attestation || 'direct',
+        attestation,
         pubKeyCredParams: [
             {
                 type: 'public-key',

--- a/packages/server/src/registration.js
+++ b/packages/server/src/registration.js
@@ -43,7 +43,7 @@ exports.parseRegisterRequest = (body) => {
     };
 };
 
-exports.generateRegistrationChallenge = ({ relyingParty, user } = {}) => {
+exports.generateRegistrationChallenge = ({ relyingParty, user, attestation } = {}) => {
     if (!relyingParty || !relyingParty.name || typeof relyingParty.name !== 'string') {
         throw new Error('The typeof relyingParty.name should be a string');
     }
@@ -63,7 +63,7 @@ exports.generateRegistrationChallenge = ({ relyingParty, user } = {}) => {
             displayName: user.displayName || user.name,
             name: user.name
         },
-        attestation: 'direct',
+        attestation: attestation || 'direct',
         pubKeyCredParams: [
             {
                 type: 'public-key',


### PR DESCRIPTION
This adds the option of passing an `attestation` value to `generateRegistrationChallenge` so that you can request attestation modes other than `direct`.