### PR TITLE
Fix lerna config to match existing project setup

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,6 @@
 {
+  "npmClient": "yarn",
+  "useWorkspaces": true,
   "packages": [
     "example/*",
     "packages/*"


### PR DESCRIPTION
The project has `yarn.lock` files and a `workspace` property in `package.json`, but the `lerna.json` is missing the configuration values to actually bootstrap using Yarn workspaces.

This PR adds `npmClient` and `useWorkspaces` to the Lerna config so that `lerna bootstrap` installs dependencies via yarn correctly.
