### PR TITLE
feat: add support for excludeCredentials

### DIFF
--- a/packages/server/src/registration.js
+++ b/packages/server/src/registration.js
@@ -43,7 +43,7 @@ exports.parseRegisterRequest = (body) => {
     };
 };
 
-exports.generateRegistrationChallenge = ({ relyingParty, user, authenticator = 'cross-platform', attestation = 'direct' } = {}) => {
+exports.generateRegistrationChallenge = ({ relyingParty, user, authenticator = 'cross-platform', attestation = 'direct', excludeCredentials = [] } = {}) => {
     if (!relyingParty || !relyingParty.name || typeof relyingParty.name !== 'string') {
         throw new Error('The typeof relyingParty.name should be a string');
     }
@@ -80,6 +80,7 @@ exports.generateRegistrationChallenge = ({ relyingParty, user, authenticator = '
         ],
         authenticatorSelection: {
             authenticatorAttachment: authenticator
-        }
+        },
+        excludeCredentials
     };
 };


### PR DESCRIPTION
https://developers.yubico.com/WebAuthn/WebAuthn_Developer_Guide/WebAuthn_Client_Registration.html

https://www.w3.org/TR/webauthn/#dictionary-makecredentialoptions

Can be used to prevent a single webauthn authenticator to be used multiple times for a single user account, which may impose a security risk (https://github.com/w3c/webauthn/issues/1235#issuecomment-501646115).