### PR TITLE
fix: Added browserlist for parcel bundler support

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.3",
   "main": "dist/main.js",
   "module": "src/index.js",
+  "browserslist": "last 2 Firefox versions",
   "repository": {
     "type": "git",
     "url": "https://github.com:wallix/webauthn.git",


### PR DESCRIPTION
This will for example automatically transpile arrow functions in this lib in the user's bundler if the user needs to support ie11.
